### PR TITLE
HGET: Version 1.3 w/ TCP-IP 1.1 support and HTTPS support

### DIFF
--- a/SRC/NETWORK/hget.c
+++ b/SRC/NETWORK/hget.c
@@ -1671,7 +1671,7 @@ void OpenTcpConnection()
         Terminate(strNoNetwork);
     } else if(regs.Bytes.A != 0) {
         sprintf(Buffer, "Unexpected error when opening TCP connection (%i)", regs.Bytes.A);
-		if ((useHttps)&&(regs.Bytes.A == ERR_NO_CONN)) //C should have the reason
+		if (regs.Bytes.A == ERR_NO_CONN) //C should have the reason
 		{
 			if (regs.Bytes.C >= TCP_CONN_FAILURE_KNOWN_REASONS)
 				printf("\r\n%s",strConnFailureReasons[TCP_CONN_FAILURE_KNOWN_REASONS]);

--- a/SRC/NETWORK/hget.c
+++ b/SRC/NETWORK/hget.c
@@ -1497,18 +1497,17 @@ void UpdateReceivingMessage()
 
     if(!localFileIsConsole) {
 		if (contentLength)
-		{
-			if (currentBlock>=blockSize)
-			{
-				currentBlock-=blockSize;
-				print("=");
-			}
-
+		{			
 			if (isFirstUpdate)
 			{
 				isFirstUpdate=false;
-				print("\r[                         ]\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d\x1d");				
+				print("\r[                         ]\r\x1c");
 			}
+			while (currentBlock>=blockSize)
+			{
+				currentBlock-=blockSize;
+				print("=");
+			}			
 		}
 		else
 		{


### PR DESCRIPTION
- Check if TLS is supported by UNAPI implementation
- Check if UNAPI implementation supports safe TLS (validating host certificate)
- If protocol is HTTPS and UNAPI implementation supports TLS, open connection using TLS
- Added /u to allow UNSAFE https transfers if adapter supports safe TLS connections
- Added /n to allow to not check hostname if adapter supports safe TLS connections
- There is no need for waiting for an extra tick after calling TCPIP_WAIT. Implementations will make sure of that, if they need it. 
- Changed the progress indication, now a progress bar that is increased in 4% increments. This is easier on CPU/VDP waits and allow faster adapters to get more data instead of waiting for screen to be updated. If file size is unknown, a star-like movement is show to indicate program is not stuck.
- When connection closed reason is available, show it always, even for implementations that do not block on TCP_OPEN.