### PR TITLE
Insert a #FF at the end of Options in DHCP packets

### DIFF
--- a/SRC/INL/INL-RES.ASM
+++ b/SRC/INL/INL-RES.ASM
@@ -43,7 +43,7 @@ LINK:	equ	1
 ;--- INL and TCP/IP UNAPI version number
 
 INL_VER1:	equ	2
-INL_VER2:	equ	2
+INL_VER2:	equ	3
 TCPIP_VER1:	equ	1
 TCPIP_VER2:	equ	1
 

--- a/SRC/INL/INL-RES.ASM
+++ b/SRC/INL/INL-RES.ASM
@@ -7867,16 +7867,13 @@ SDHCP_OKFRM:
 
 	ld	(hl),b
 
-	; Begin of changes
 	; Include a #FF at the end of DHCP packet
 	; to properly end Options Section.
 	; Some routers ignore DHCP packets without this.
 
-	ld(ix), #FF 
+	ld  (ix),#FF 
 	inc ix 
 	inc b 
-
-	; End of changes
 
 SDHCP_OKREQOPS:
 

--- a/SRC/INL/INL-RES.ASM
+++ b/SRC/INL/INL-RES.ASM
@@ -7866,6 +7866,18 @@ SDHCP_OKFRM:
 	;Set option length
 
 	ld	(hl),b
+
+	; Begin of changes
+	; Include a #FF at the end of DHCP packet
+	; to properly end Options Section.
+	; Some routers ignore DHCP packets without this.
+
+	ld(ix), #FF 
+	inc ix 
+	inc b 
+
+	; End of changes
+
 SDHCP_OKREQOPS:
 
 	;--- Packet is complete: calculate resulting size

--- a/SRC/INL/INL-TRAN.ASM
+++ b/SRC/INL/INL-TRAN.ASM
@@ -1390,12 +1390,12 @@ INIT_S:
 	db	"InterNestor Lite for the Ethernet UNAPI"
 	endif
 
-	db	" v2.2: TCP/IP stack for MSX-DOS",13,10
+	db	" v2.3: TCP/IP stack for MSX-DOS",13,10
 
 	if	USETIMI=0
 	db	"*** NO TIMER!!",13,10
 	endif
-	db	"By Konamiman, 8/2019",13,10,13,10,"$"
+	db	"By Konamiman, 2/2023",13,10,13,10,"$"
 
 INFO_S:	db	"Frequently used options:",13,10,13,10
 


### PR DESCRIPTION
Some routers drops DHCP packets without an #FF in the end of Options section of payload. 